### PR TITLE
Fixes to support latest Barclays changes

### DIFF
--- a/account.js
+++ b/account.js
@@ -35,6 +35,7 @@ module.exports = class Account {
       await this.page.waitForTimeout(1000);
 
       if (!(await this.page.$('a.export'))) {
+        console.warn("Warning: StatementOFX clicking a.export failed");
         await this.session.home();
         return null;
       }

--- a/barclayscrape.js
+++ b/barclayscrape.js
@@ -76,7 +76,7 @@ program
         console.error(err);
       }
     } catch (err) {
-      console.error(err);
+      console.error("Exception in get_ofx_combined: " + err);
       return;
     } finally {
       await sess.close();
@@ -91,19 +91,24 @@ program
     try {
       sess = await auth();
     } catch (err) {
-      console.error(err);
+      console.error("Exception in auth: " + err);
       return;
     }
 
     try {
       const accounts = await sess.accounts();
+      var serv = new services(sess);
       for (let account of accounts) {
-        const ofx = await account.statementOFX();
-        if (ofx) {
-          await fs_writeFile(path.join(out_path, exportLabel(account)) + '.ofx', ofx);
+        try {
+          await sess.home();
+          await serv.get_ofx_for_account(out_path, account.number);
+        } catch (err) {
+          console.error("Exception in get_ofx_for_account: " + err);
         }
       }
+      
     } catch (err) {
+      console.log("Exception in get_ofx cmd: " + err);
       console.error(err);
       process.exit(1);
     } finally {

--- a/services.js
+++ b/services.js
@@ -9,14 +9,46 @@ module.exports = class Services {
 	  this.page = session.page;
 	}
 
-	async get_ofx_combined(out_path) {
+	async select_account_to_download(account_number) {
+		try {
+			// try to expand dropdown list
+			await u.wait(this.page, "#productIdentifier p");
+			await u.click_nonav(this.page, "#productIdentifier p");
+
+			// default to MS Money 2002 export format
+			const optionid_ofx = 7;
+			const format_input = "input[type='radio'][name='reqSoftwarePkgCode'][value='" + optionid_ofx + "']";;
+			const format_selector = "div.option:has("+format_input+")";
+			await u.wait(this.page, format_selector);
+			await u.click_nonav(this.page, format_selector);
+
+			// select account item in list
+			const selector_account = "input[type='radio'][name='productIdentifier'][value='" + account_number + "']";
+			const label_selector = "div.option:has("+selector_account+")";
+			await u.wait(this.page, label_selector);
+			await u.click_nonav(this.page, label_selector);
+			return true;
+		}
+		catch (err) {
+			console.log("Exception in select_account_to_download: " + err);
+			throw err;
+		}
+	}
+
+	async get_ofx_combined(out_path, account_number) {
+		await this.get_ofx_for_account(out_path, null);
+	}
+
+	async get_ofx_for_account(out_path, account_number) {
 		// Barclays emits the download as data.ofx, unclear how to override this currently
-		let dest_basename = 'data.ofx'
-		let dest_filename = path.join(out_path, dest_basename)
+		let default_filename = path.join(out_path, 'data.ofx');
+		let dest_basename = account_number != null ? (account_number + '.ofx') : 'data.ofx';
+		let dest_filename = path.join(out_path, dest_basename);
 	
 		// delete any existing dest_filename in out_path
 		try {
-			await fs.unlink(dest_filename)
+			fs.unlinkSync(default_filename);
+			fs.unlinkSync(dest_filename);
 		} catch(err) {
 		}
 
@@ -26,13 +58,53 @@ module.exports = class Services {
 		
 		// wait for download form 
 		await this.page.waitForSelector("form[name='process-form']");
+
+		if (account_number != null) {
+			try {
+				await this.select_account_to_download(account_number);
+			}
+			catch (err) {
+				console.error('Error selecting account to download: ' + err)
+				return null;
+			}
+		}
 	
 		// click next in download dialog
 		await this.page.waitForSelector("input[type='submit']#next_step1");
 		await this.page.click("input[type='submit']#next_step1");
 
+		// if were downloading for single account, check if its asking for a date range to be input
+		// then grab the fullest extent based on its suggestion
+		if (account_number != null) {
+			await this.page.waitForSelector("div#modal-core div.main p strong");
+			const default_dates = await this.page.$$eval('div#modal-core div.main p strong', (elements) => {
+				const matches = [];
+				elements.forEach(element => {
+					let date_regex = /[0-9]{2}\/[0-9]{2}\/[0-9]{4}/;
+					if (date_regex.test(element.textContent)) {
+					matches.push(element.textContent);
+				  }
+				});
+				return matches;
+			  });
+
+			  if (default_dates.length < 2) {
+				await u.dump_screenshot(this.page);
+				throw new Error(`Failed to parse 2 dates from get_ofx download modal. Screenshot saved to error.png`);
+			  }
+
+			  await this.page.waitForSelector("input#fromExportDate");
+			  await u.fillField(this.page, "input#fromExportDate", default_dates[0]);
+
+			  await this.page.waitForSelector("input#toExportDate");
+			  await u.fillField(this.page, "input#toExportDate", default_dates[1])
+
+			  await this.page.waitForSelector("input[type='submit']#next_step1a");
+			  await u.click_nonav(this.page, "input[type='submit']#next_step1a");
+		}
+
 		// click download button
-		let download_button = "input[type='submit']#data-download";
+		let download_button = "input#data-download";
 		await this.page.waitForSelector(download_button);
 		
 		const client = await this.page.target().createCDPSession();
@@ -40,18 +112,33 @@ module.exports = class Services {
 		await this.page.click(download_button);
 
 		// delay for download (is there a more reliable way to detect a completed download response?)
-		await this.page.waitForTimeout(3000);
+		await this.page.waitForTimeout(2000);
 	
-		// verify existence of download file
+		// error checking for existence of download file
 		try {
-		  if (fs.existsSync(dest_filename)) {
-			console.log('OFX file exported as: ' + dest_filename)
-		  }
-		  else {
-			console.log('Error: ' + dest_filename + ' does not exist after attempting OFX download')
-		  }
+			if (!fs.existsSync(default_filename)) {
+				console.log('Error: ' + dest_filename + ' does not exist after attempting OFX download');
+				return false;
+			}
+
+			try {
+				fs.renameSync(default_filename, dest_filename);
+			} catch (err) {
+				console.log('Error: Failed to rename "' + default_filename + '" to "' + dest_filename + '"');
+				return false;
+			}
+			
+			/*if (!fs.existsSync(dest_filename)) {
+				console.log('Error: Downloaded and renamed file does not exist: ' + dest_filename);
+				return false;
+			}*/
+
+			console.log('Exported: ' + dest_filename);
 		} catch(err) {
-		  console.error('Error: ' + err)
+			console.error('Error in get_ofx_for_account: ' + err);
+			return false;
 		}
-	}
+
+		return true;
+	}	
 }

--- a/session.js
+++ b/session.js
@@ -8,11 +8,11 @@ class Session {
     this.page = await this.browser.newPage();
     this.logged_in = false;
 
-  // .accounts_body - used for business banking and pre-2023 personal banking
-  // div.c-section.c-section--primary - used for post-2023 personal banking
-  this.selector_IsLoggedIn = '.accounts-body, div.c-section.c-section--primary';
+    // .accounts_body - used for business banking and pre-2023 personal banking
+    // div.c-section.c-section--primary - used for post-2023 personal banking
+    this.selector_IsLoggedIn = '.accounts-body, div.c-section.c-section--primary';
 
-  //this.page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+    //this.page.on('console', msg => console.log('PAGE LOG:', msg.text()));
     await this.page.setViewport({width: 1000, height: 1500});
     await this.page.goto('https://bank.barclays.co.uk');
   }
@@ -56,7 +56,6 @@ class Session {
   }
 
   async ensureLoggedIn() {
-    // using this selector for site redesign, but not confirmed its appropriate yet
     await u.wait(this.page, this.selector_IsLoggedIn);
     this.logged_in = true;
   }
@@ -187,23 +186,15 @@ class Session {
         return;
       }
 
-      res.push(
-        new Account(
-          this,
-          a[0],
-          a[1],
-          a[2],
-          a[3]
-        ),
-      );
+      res.push(new Account(this, a[0], a[1], a[2], a[3]));
     });
     return res;
   }
 
   async home() {
-    await u.wait(this.page, "a[href$='/olb/balances/digital/btr/home']");
-    await u.click(this.page, "a[href$='/olb/balances/digital/btr/home']");
-    await u.wait(this.page, this.selector_IsLoggedIn);
+      await u.wait(this.page, "a[href$='/olb/balances/digital/btr/home']");
+      await u.click(this.page, "a[href$='/olb/balances/digital/btr/home']");
+      await u.wait(this.page, this.selector_IsLoggedIn);
   }
 }
 

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 
 // Look for a warning on the page and raise it as an error.
-async function raiseWarning(page, action, selector) {
+async function check_for_webpage_warning(page, action, selector) {
   const warning = await page.$('.notification--warning');
   if (!warning) {
     return
@@ -13,7 +13,7 @@ async function raiseWarning(page, action, selector) {
 
 exports.dump_html_to = async(page, filename) => {
   const html = await page.content();
-  await fs.writeFileSync(filename, html);
+  fs.writeFileSync(filename, html);
 }
 
 exports.dump_screenshot_to = async(page, filename) => {
@@ -35,7 +35,7 @@ exports.dump_html = async(page) => {
 
 // Click element then wait for any subsequent navigation to complete
 exports.click = async (page, selector) => {
-  click_withnav(page, selector, true)
+  await click_withnav(page, selector, true)
 };
 
 // Click element without waiting for subsequent navigation (ie, clientside UI javascript) 
@@ -57,7 +57,7 @@ click_withnav = async (page, selector, wait_for_nav) => {
       ]);
     }
   } catch (err) {
-    raiseWarning(page, 'clicking', selector);
+    check_for_webpage_warning(page, 'clicking', selector);
 
     await exports.dump_screenshot(page);
     throw `Error when clicking ${selector} on URL ${page.url()}: ${err}`;
@@ -84,7 +84,7 @@ exports.wait = async (page, selector) => {
   try {
     await page.waitForSelector(selector, {timeout: 30000});
   } catch (err) {
-    raiseWarning(page, 'fetching', selector);
+    check_for_webpage_warning(page, 'fetching', selector);
 
     await exports.dump_screenshot(page);
     throw new Error(`Couldn't find selector ${selector} on page ${page.url()}. Screenshot saved to error.png`);


### PR DESCRIPTION
get_ofx no longer tries to parse transactions from account view, but uses similar export process to get_ofx_combined Explicitly select OFX format when downloading
For single OFX, parse and use the date range suggested by website Refactoring of various error handling